### PR TITLE
Update README with correct event name

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 3. do your things...
 
 ```js
-document.addEventListener('autocomplete', function(e) {
+document.addEventListener('onautocomplete', function(e) {
   e.target.hasAttribute('autocompleted'); // true or false
   e.preventDefault(); // prevent autofill
   // do you stuff...


### PR DESCRIPTION
This tripped me up for longer than I'd like to admit, but the event name to listen for is `onautocomplete` not `autocomplete`