### PR TITLE
Add null checks in case element no longer exists

### DIFF
--- a/src/detect-autofill.js
+++ b/src/detect-autofill.js
@@ -40,7 +40,7 @@ function onInput(event) {
  * @param {HtmlInputElement} element
  */
 function autocomplete(element) {
-  if (element.hasAttribute('autocompleted')) return;
+  if (!element || element.hasAttribute('autocompleted')) return;
   element.setAttribute('autocompleted', '');
 
   var event = new window.CustomEvent('onautocomplete', {
@@ -63,7 +63,7 @@ function autocomplete(element) {
  * @param {HtmlInputElement} element
  */
 function cancelAutocomplete(element) {
-  if (!element.hasAttribute('autocompleted')) return;
+  if (!element || !element.hasAttribute('autocompleted')) return;
   element.removeAttribute('autocompleted');
 
   // dispatch event


### PR DESCRIPTION
It's possible for event.target to be undefined when `autocomplete(event.target)` and `cancelAutocomplete(event.target)` are called, so adding null checks here to exit early if so.